### PR TITLE
Data generation command-line options, added additional search options on main page (filter by testament, adjust number of returned verses)

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,8 @@ st.set_page_config(
 def setup():
     embeddings = HuggingFaceInstructEmbeddings(
         model_name="hkunlp/instructor-large",
+        # NOTE: Not changing the capitalization in this query instruction until the database is regenerated.  Not sure if it will make a difference or not, but better safe than sorry. Once the data is regenerated, then update this line to ensure that the prompt text matches again.
+        #query_instruction="Represent the religious Bible verse text for semantic search:",
         query_instruction="Represent the Religious Bible verse text for semantic search:",
     )
     db = Chroma(

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,37 @@
+# Biblos Data Back-End
+
+This code is responsible for processing Bible text into a Chroma database.
+
+It intakes Bible text in Verse Per Line (VPL) format and outputs a SQLite database of verse embeddings.
+
+To do this, it groups verses from each chapter together, then breaks them up to try to limit the amount of tokens in each document.  It then embeds each document with some metadata about the verse.
+
+## Usage:
+
+### For command-line options
+```
+python create_db.py -h
+```
+
+### For default usage
+```
+python create_db.py
+```
+
+### Please note
+This will take a long time to generate embeddings for all 4k+ passages of scripture -- on an M1 Macbook Pro, this takes approx. 18 minutes.
+
+## VPL Format
+
+This script parses `v` tags from an XML document, assuming one verse per tag.
+
+Example:
+```
+<verseFile>
+  <v b="GEN" c="1" v="1">In the beginning, God created the heavens and the earth. </v>
+  <v b="GEN" c="1" v="2">The earth was formless and empty. Darkness was on the surface of the deep and God’s Spirit was hovering over the surface of the waters. </v>
+  <v b="GEN" c="1" v="3">God said, “Let there be light,” and there was light. </v>
+  ...
+```
+
+Any XML file that has `<v>` elements with `b`, `c`, and `v` tags will function for this processor.

--- a/data/create_db.py
+++ b/data/create_db.py
@@ -1,15 +1,60 @@
 import xml.etree.ElementTree as ET
 import collections
+import sys
+import argparse
+from datetime import datetime
 
 from langchain.text_splitter import CharacterTextSplitter
 from langchain.vectorstores import Chroma
 from langchain.schema import Document
 from langchain.embeddings import HuggingFaceInstructEmbeddings
 
+# Accept the following arguments:
+#  -input_file (-i) : path to input VPL file (default: "./engwebp_vpl.xml")
+#  -model_name (-m) : name of the HuggingFace model to use (default: "hkunlp/instructor-large")
+#  -query_instruction (-q) : query instruction to use (default: "Represent the religious Bible verse text for semantic search:")
+#  -output_dir (-o) : path to base output directory (default: "./db")
+
+input_file = "./engwebp_vpl.xml"
+model_name = "hkunlp/instructor-large"
+query_instruction = "Represent the religious Bible verse text for semantic search:"
+output_dir = "./db"
+
+# Parse the command-line arguments
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-i", "--input_file", default=input_file, help=f"path to input VPL fil (expected .xml format, default {input_file})")
+parser.add_argument("-m", "--model_name", default=model_name, help=f"name of the HuggingFace model to use (default: {model_name})")
+parser.add_argument("-q", "--query_instruction", default=query_instruction, help=f"query instruction to use (default: \"{query_instruction}\")")
+parser.add_argument("-o", "--output_dir", default=output_dir, help="path to base output directory. The output directory will be modified to reflect the input_file and model_name parameters if they are different from their defaults.")
+args = parser.parse_args()
+
+output_dir = args.output_dir
+
+# If any of the arguemnts are not at their default, then modify the output_dir to reflect the arguments
+if args.input_file != input_file:
+    input_file = args.input_file
+    output_dir = output_dir + "_" + input_file.split('/')[-1].split('.')[0]
+if args.model_name != model_name:
+    model_name = args.model_name
+    output_dir = output_dir + "_" + model_name.replace("/", "_")
+if args.query_instruction != query_instruction:
+    query_instruction = args.query_instruction
+    # TODO: Should we include the query instruction in the output_dir?
+
+print(f"input_file: {input_file}")
+print(f"model_name: {model_name}")
+print(f"query_instruction: {query_instruction}")
+print(f"output_dir: {output_dir}")
+
 # Load XML
-tree = ET.parse("./engwebp_vpl.xml")
+tree = ET.parse(input_file)
 root = tree.getroot()
 
+then = datetime.now()
+
+print()
+print("Parsing XML, grouping verses by chapter...")
 # Group verses by chapter
 verses_by_chapter = collections.defaultdict(list)
 for verse in root.findall("v"):
@@ -20,12 +65,21 @@ for verse in root.findall("v"):
 
     verses_by_chapter[(book, chapter)].append((verse_num, text))
 
+print(f' {sum(len(verses) for verses in verses_by_chapter.values())} verses found')
+print(f' {len(verses_by_chapter)} chapters found')
+
+print(f'Creating documents for each chapter...')
 # Create document for each chapter
 documents = []
+testament="OT"
+
 for (book, chapter), verses in verses_by_chapter.items():
     chapter_text = ""
     for verse_num, text in verses:
         chapter_text += f"{text}\n"
+
+    if book.lower().startswith("mat"):
+        testament = "NT"
 
     verse_nums_as_string = ",".join(str(verse_num) for verse_num, text in verses)
     doc = Document(page_content=chapter_text)
@@ -33,6 +87,7 @@ for (book, chapter), verses in verses_by_chapter.items():
         "book": book,
         "chapter": chapter,
         "verse_nums": verse_nums_as_string,
+        "testament": testament,
     }
     documents.append(doc)
 
@@ -46,26 +101,31 @@ verse_splitter = CharacterTextSplitter(
 )
 bible = verse_splitter.split_documents(documents)
 
+print(f' {len(bible)} documents created from {len(documents)} chapters')
+
 # Load embeddings
-print("loading embeddings")
+print(f"Loading embeddings from model {model_name}...")
 embedding_function = HuggingFaceInstructEmbeddings(
-    model_name="hkunlp/instructor-large",
-    query_instruction="Represent the Religious Bible verse text for semantic search:",
+    model_name=model_name,
+    query_instruction=query_instruction,
     encode_kwargs = {'normalize_embeddings': True},
     model_kwargs = {"device": "cpu"}
 )
 
 # Create Chroma database
-print("initializing db")
+print(f"Initializing db and creating embeddings to {output_dir} (please be patient, this will take a while)...")
 db = Chroma.from_documents(
     bible,
     embedding_function,
-    persist_directory="./output_db",
+    persist_directory=output_dir,
     collection_metadata={"hnsw:space": "cosine"},
 )
 
-print("persisting db")
+print("Saving database...")
 db.persist()
 
-print("done")
+completed_at = datetime.now()
+elapsed_time_s = (completed_at - then).total_seconds()
+
+print(f"Completed in {elapsed_time_s} seconds")
 exit()


### PR DESCRIPTION
* Added command-line options to the data creation script to give easier control for testing various Bible translations, models, or other parameters.  

* Added `testament` as another metadata parameter for each verse so that we can more easily filter by OT or NT. 

* Adjusted capitalization in prompt text to change "Religious" to 'religious'

* ~~Added filters on main page to limit search to OT or NT.~~
    * _Now removed from here and added via PR #9 ._

* ~~Added slider to control the number of verses returned.~~
    * _Now removed from here and added via PR #8 ._

* ~~Added fallback mechanism to support limited functionality (verse similarity search only) if no Claude API key is present.~~
    * _Now removed from here and added via PR #7 ._
