### PR TITLE
LLM error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ db, llm = setup()
 
 st.title("Biblos: Exploration Tool")
 
-prompt = "Can you provide key points about what these specific passages from the following texts say about the given topic, including related chapter and verse reference? Please restrict your summary to the content found exclusively in these verses and do not reference other biblical verses or context. Explain how they relate to eachother, theologically, in the context of the meta narrative of the gospel, across old and new testaments. The topic is: "
+prompt = "Can you provide key points about what these specific passages from the following texts say about the given topic, including related chapter and verse reference? Please restrict your summary to the content found exclusively in these verses and do not reference other biblical verses or context. Explain how they relate to each other, theologically, in the context of the meta narrative of the gospel, across Old and New Testaments. The topic is: "
 
 default_query = "What did Jesus say about eternal life?"
 


### PR DESCRIPTION
# Summary of Changes

* Adds a friendly error message in the event that there is no Anthropic API key.  This simplifies the process of running the app locally by simply disabling LLM summarization, but still providing the other elements of semantic verse retrieval.

* Minor: Fixes a couple of small typos in the LLM summarization prompt

# Feature Screenshot:

<img width="1513" alt="image" src="https://github.com/dssjon/biblos/assets/796749/9e740f07-0ef9-4e4b-9aaf-6738736c9e2c">
