### PR TITLE
Testament Filter #2

### DIFF
--- a/app.py
+++ b/app.py
@@ -92,6 +92,9 @@ with st.expander("Search Options"):
 # Build a search filter for the testaments
 if ot != nt:
     if ot:
+        # NOTE: If / when the database has `testament` added as a metadata field, then this can be simplified to:
+        #  testament_filter = {"testament": "OT"}
+        #  Also, the `testaments` dictionary could then be removed, along with all of its associated code in `setup()`
         testament_filter = {"$or": testaments["OT"]}
     else:
         testament_filter = {"$or": testaments["NT"]}

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from langchain.embeddings import HuggingFaceInstructEmbeddings
 from langchain.chat_models import ChatAnthropic
 import streamlit as st
 import streamlit_analytics
+from datetime import datetime
 
 streamlit_analytics.start_tracking(load_from_json="./data/analytics.json")
 
@@ -101,12 +102,16 @@ if ot != nt:
 else:
     testament_filter = None
 
+then = datetime.now()
+
 search_results = db.similarity_search_with_relevance_scores(
     search_query,
     k=num_verses_to_retrieve,
     score_function="cosine",
     filter=testament_filter,
 )
+
+st.markdown(f'*retrieved {len(search_results)} results in {datetime.now() - then}*')
 
 col1, col2 = st.columns([1, 1])
 


### PR DESCRIPTION
# Feature Summary

* Adds a search parameters dropdown and two checkboxes to optionally limit searches to only OT or NT.

* If both OT and NT are unchecked, then functions the same as if both are checked.

* Added small performance timer to gauge the performance impact of these filters

NOTE: This implementation does NOT require any additional metadata to be added to the database.  However, during setup it does need to iterate through all of the data to compile a list of books of the Bible.  This operation does add some latency to startup (because it queries every item in the index), but because everything is local, it's hopefully not too bad.

NOTE: This implementation is also less than ideal in that it creates a very large OR clause that joins all books of the Old and New Testaments together to filter metadata.  I.E., 
```
filter = {"$or": [{"book": "GEN"}, {"book": "EXO"}, {"book": "LEV"} ... ]}
```

It can be a bit of a long conditional clause, but it still seems to be pretty zippy running locally on my Macbook Pro.

And on the plus side, no database schema updates are required in order for this to function! :)

# Feature Screenshot

<img width="911" alt="image" src="https://github.com/dssjon/biblos/assets/796749/0ba35b24-4772-4703-a3c0-837b8168aae1">
